### PR TITLE
Port to 0.26/update rust-miniscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 5.0.0 - Jan 14, 2021
+
+- Remove `PkCtx` from the API
+- Move descriptors into their own types, with an enum containing all of them
+- Move descriptor functionality into a trait
+- Remove `FromStr` bound from `MiniscriptKey`and `MiniscriptKey::Hash`
+- Various `DescriptorPublicKey` improvements
+- Allow hardened paths in `DescriptorPublicKey`, remove direct `ToPublicKey` implementation
+- Change `Option` to `Result` in all APIs
+- bump `rust-bitcoin` to 0.26
+
 # 4.0.0 - Nov 23, 2020
 
 - Add support for parsing secret keys

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ use-serde = ["bitcoin/use-serde", "serde"]
 rand = ["bitcoin/rand"]
 
 [dependencies]
-bitcoin = "0.25"
-elements = "0.15"
-miniscript = {git = "https://github.com/rust-bitcoin/rust-miniscript", rev = "a65f03e8f874a12d2cf5349384583d88ace14502"}
+bitcoin = "0.26"
+elements = "0.16"
+miniscript = "5.1.0"
 
 [dev-dependencies]
 serde_json = "<=1.0.44"

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -17,7 +17,7 @@
 extern crate bitcoin;
 extern crate elements_miniscript as miniscript;
 
-use miniscript::DescriptorTrait;
+use miniscript::{descriptor::DescriptorType, DescriptorTrait};
 use std::str::FromStr;
 
 fn main() {
@@ -45,4 +45,11 @@ fn main() {
         format!("{:x}", my_descriptor.explicit_script()),
         "21020202020202020202020202020202020202020202020202020202020202020202ac"
     );
+
+    let desc = miniscript::Descriptor::<bitcoin::PublicKey>::from_str(
+        "elsh(wsh(c:pk_k(020202020202020202020202020202020202020202020202020202020202020202)))",
+    )
+    .unwrap();
+
+    assert!(desc.desc_type() == DescriptorType::ShWsh);
 }

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -13,7 +13,12 @@ fn do_test(data: &[u8]) {
         let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
         let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
 
-        let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
+        // Before doing anything check the special case
+        // To make sure that el are not treated as wrappers
+        let normalize_aliases = s
+            .replace("elc:pk_h(", "elpkh(")
+            .replace("elc:pk_k(", "elpk(");
+        let normalize_aliases = multi_wrap_pk_re.replace_all(&normalize_aliases, "$1:pk(");
         let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
         let normalize_aliases = normalize_aliases
             .replace("c:pk_k(", "pk(")
@@ -65,6 +70,6 @@ mod tests {
     use super::*;
     #[test]
     fn test() {
-        do_test(b"pkh()");
+        do_test(b"elc:pk_h()");
     }
 }

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -13,12 +13,7 @@ fn do_test(data: &[u8]) {
         let multi_wrap_pk_re = Regex::new("([a-z]+)c:pk_k\\(").unwrap();
         let multi_wrap_pkh_re = Regex::new("([a-z]+)c:pk_h\\(").unwrap();
 
-        // Before doing anything check the special case
-        // To make sure that el are not treated as wrappers
-        let normalize_aliases = s
-            .replace("elc:pk_h(", "elpkh(")
-            .replace("elc:pk_k(", "elpk(");
-        let normalize_aliases = multi_wrap_pk_re.replace_all(&normalize_aliases, "$1:pk(");
+        let normalize_aliases = multi_wrap_pk_re.replace_all(&s, "$1:pk(");
         let normalize_aliases = multi_wrap_pkh_re.replace_all(&normalize_aliases, "$1:pkh(");
         let normalize_aliases = normalize_aliases
             .replace("c:pk_k(", "pk(")
@@ -70,6 +65,6 @@ mod tests {
     use super::*;
     #[test]
     fn test() {
-        do_test(b"elc:pk_h()");
+        do_test(b"pkh()");
     }
 }

--- a/src/descriptor/blinded.rs
+++ b/src/descriptor/blinded.rs
@@ -90,6 +90,8 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Blinded<Pk> {
 
 impl<Pk: MiniscriptKey> FromTree for Blinded<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -115,6 +117,8 @@ where
 
 impl<Pk: MiniscriptKey> FromStr for Blinded<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -129,6 +133,8 @@ where
 
 impl<Pk: MiniscriptKey> ElementsTrait<Pk> for Blinded<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -148,6 +154,8 @@ where
 
 impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Blinded<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -101,6 +101,7 @@ pub(super) fn verify_checksum(s: &str) -> Result<&str, Error> {
 }
 
 /// Helper function to strip checksum without verifying
+#[allow(dead_code)]
 pub(super) fn strip_checksum(s: &str) -> &str {
     let mut parts = s.splitn(2, '#');
     parts.next().unwrap()

--- a/src/descriptor/covenants/mod.rs
+++ b/src/descriptor/covenants/mod.rs
@@ -65,7 +65,7 @@ use {
         types,
     },
     util::varint_len,
-    Miniscript, ScriptContext, Segwitv0, TranslatePk,
+    ForEach, ForEachKey, Miniscript, ScriptContext, Segwitv0, TranslatePk,
 };
 
 use super::{
@@ -541,6 +541,8 @@ impl CovenantDescriptor<bitcoin::PublicKey> {
 
 impl<Pk: MiniscriptKey> FromTree for CovenantDescriptor<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -576,6 +578,8 @@ impl<Pk: MiniscriptKey> fmt::Display for CovenantDescriptor<Pk> {
 
 impl<Pk: MiniscriptKey> FromStr for CovenantDescriptor<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -590,6 +594,8 @@ where
 
 impl<Pk: MiniscriptKey> ElementsTrait<Pk> for CovenantDescriptor<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -611,6 +617,8 @@ where
 
 impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for CovenantDescriptor<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -690,6 +698,16 @@ where
         Pk: ToPublicKey,
     {
         self.explicit_script()
+    }
+}
+
+impl<Pk: MiniscriptKey> ForEachKey<Pk> for CovenantDescriptor<Pk> {
+    fn for_each_key<'a, F: FnMut(ForEach<'a, Pk>) -> bool>(&'a self, mut pred: F) -> bool
+    where
+        Pk: 'a,
+        Pk::Hash: 'a,
+    {
+        pred(ForEach::Key(&self.pk)) && self.ms.for_any_key(pred)
     }
 }
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -3,9 +3,11 @@ use std::{error, fmt, str::FromStr};
 use bitcoin::{
     self,
     hashes::hex::FromHex,
+    hashes::Hash,
     secp256k1,
     secp256k1::{Secp256k1, Signing},
     util::bip32,
+    XpubIdentifier,
 };
 
 use MiniscriptKey;
@@ -343,6 +345,64 @@ impl fmt::Display for ConversionError {
 impl error::Error for ConversionError {}
 
 impl DescriptorPublicKey {
+    /// The fingerprint of the master key associated with this key
+    pub fn master_fingerprint(&self) -> bip32::Fingerprint {
+        match *self {
+            DescriptorPublicKey::XPub(ref xpub) => {
+                if let Some((fingerprint, _)) = xpub.origin {
+                    fingerprint
+                } else {
+                    xpub.xkey.fingerprint()
+                }
+            }
+            DescriptorPublicKey::SinglePub(ref single) => {
+                if let Some((fingerprint, _)) = single.origin {
+                    fingerprint
+                } else {
+                    let mut engine = XpubIdentifier::engine();
+                    single
+                        .key
+                        .write_into(&mut engine)
+                        .expect("engines don't error");
+                    bip32::Fingerprint::from(&XpubIdentifier::from_engine(engine)[..])
+                }
+            }
+        }
+    }
+
+    /// Full path, from the master key
+    ///
+    /// For wildcard keys this will return the path up to the wildcard, so you
+    /// can get full paths by appending one additional derivation step, according
+    /// to the wildcard type (hardened or normal)
+    pub fn full_derivation_path(&self) -> bip32::DerivationPath {
+        match *self {
+            DescriptorPublicKey::XPub(ref xpub) => {
+                let origin_path = if let Some((_, ref path)) = xpub.origin {
+                    path.clone()
+                } else {
+                    bip32::DerivationPath::from(vec![])
+                };
+                origin_path.extend(&xpub.derivation_path)
+            }
+            DescriptorPublicKey::SinglePub(ref single) => {
+                if let Some((_, ref path)) = single.origin {
+                    path.clone()
+                } else {
+                    bip32::DerivationPath::from(vec![])
+                }
+            }
+        }
+    }
+
+    /// Whether or not the key has a wildcards
+    pub fn is_deriveable(&self) -> bool {
+        match *self {
+            DescriptorPublicKey::SinglePub(..) => false,
+            DescriptorPublicKey::XPub(ref xpub) => xpub.wildcard != Wildcard::None,
+        }
+    }
+
     /// If this public key has a wildcard, replace it by the given index
     ///
     /// Panics if given an index ≥ 2^31
@@ -595,6 +655,15 @@ impl MiniscriptKey for DescriptorPublicKey {
     // This allows us to be able to derive public keys even for PkH s
     type Hash = Self;
 
+    fn is_uncompressed(&self) -> bool {
+        match self {
+            DescriptorPublicKey::SinglePub(DescriptorSinglePub { ref key, .. }) => {
+                key.is_uncompressed()
+            }
+            _ => false,
+        }
+    }
+
     fn to_pubkeyhash(&self) -> Self {
         self.clone()
     }
@@ -701,27 +770,59 @@ mod test {
     }
 
     #[test]
+    fn test_wildcard() {
+        let public_key = DescriptorPublicKey::from_str("[abcdef00/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/2").unwrap();
+        assert_eq!(public_key.master_fingerprint().to_string(), "abcdef00");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0'/1'/2");
+        assert_eq!(public_key.is_deriveable(), false);
+
+        let public_key = DescriptorPublicKey::from_str("[abcdef00/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/*").unwrap();
+        assert_eq!(public_key.master_fingerprint().to_string(), "abcdef00");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0'/1'");
+        assert_eq!(public_key.is_deriveable(), true);
+
+        let public_key = DescriptorPublicKey::from_str("[abcdef00/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/*h").unwrap();
+        assert_eq!(public_key.master_fingerprint().to_string(), "abcdef00");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0'/1'");
+        assert_eq!(public_key.is_deriveable(), true);
+    }
+
+    #[test]
     fn test_deriv_on_xprv() {
         let secp = secp256k1::Secp256k1::signing_only();
 
         let secret_key = DescriptorSecretKey::from_str("tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/0'/1'/2").unwrap();
         let public_key = secret_key.as_public(&secp).unwrap();
         assert_eq!(public_key.to_string(), "[2cbe2a6d/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/2");
+        assert_eq!(public_key.master_fingerprint().to_string(), "2cbe2a6d");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0'/1'/2");
+        assert_eq!(public_key.is_deriveable(), false);
 
         let secret_key = DescriptorSecretKey::from_str("tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/0'/1'/2'").unwrap();
         let public_key = secret_key.as_public(&secp).unwrap();
         assert_eq!(public_key.to_string(), "[2cbe2a6d/0'/1'/2']tpubDDPuH46rv4dbFtmF6FrEtJEy1CvLZonyBoVxF6xsesHdYDdTBrq2mHhm8AbsPh39sUwL2nZyxd6vo4uWNTU9v4t893CwxjqPnwMoUACLvMV");
+        assert_eq!(public_key.master_fingerprint().to_string(), "2cbe2a6d");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0'/1'/2'");
 
         let secret_key = DescriptorSecretKey::from_str("tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/0/1/2").unwrap();
         let public_key = secret_key.as_public(&secp).unwrap();
         assert_eq!(public_key.to_string(), "tpubD6NzVbkrYhZ4WQdzxL7NmJN7b85ePo4p6RSj9QQHF7te2RR9iUeVSGgnGkoUsB9LBRosgvNbjRv9bcsJgzgBd7QKuxDm23ZewkTRzNSLEDr/0/1/2");
+        assert_eq!(public_key.master_fingerprint().to_string(), "2cbe2a6d");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0/1/2");
 
         let secret_key = DescriptorSecretKey::from_str("[aabbccdd]tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/0/1/2").unwrap();
         let public_key = secret_key.as_public(&secp).unwrap();
         assert_eq!(public_key.to_string(), "[aabbccdd]tpubD6NzVbkrYhZ4WQdzxL7NmJN7b85ePo4p6RSj9QQHF7te2RR9iUeVSGgnGkoUsB9LBRosgvNbjRv9bcsJgzgBd7QKuxDm23ZewkTRzNSLEDr/0/1/2");
+        assert_eq!(public_key.master_fingerprint().to_string(), "aabbccdd");
+        assert_eq!(public_key.full_derivation_path().to_string(), "m/0/1/2");
 
         let secret_key = DescriptorSecretKey::from_str("[aabbccdd/90']tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/0'/1'/2").unwrap();
         let public_key = secret_key.as_public(&secp).unwrap();
         assert_eq!(public_key.to_string(), "[aabbccdd/90'/0'/1']tpubDBrgjcxBxnXyL575sHdkpKohWu5qHKoQ7TJXKNrYznh5fVEGBv89hA8ENW7A8MFVpFUSvgLqc4Nj1WZcpePX6rrxviVtPowvMuGF5rdT2Vi/2");
+        assert_eq!(public_key.master_fingerprint().to_string(), "aabbccdd");
+        assert_eq!(
+            public_key.full_derivation_path().to_string(),
+            "m/90'/0'/1'/2"
+        );
     }
 }

--- a/src/descriptor/pegin/dynafed_pegin.rs
+++ b/src/descriptor/pegin/dynafed_pegin.rs
@@ -101,6 +101,8 @@ impl<Pk: MiniscriptKey> BtcLiftable<Pk> for Pegin<Pk> {
 
 impl<Pk: MiniscriptKey> FromTree for Pegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -128,6 +130,8 @@ where
 
 impl<Pk: MiniscriptKey> FromStr for Pegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -142,6 +146,8 @@ where
 
 impl<Pk: MiniscriptKey> PeginTrait<Pk> for Pegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {

--- a/src/descriptor/pegin/legacy_pegin.rs
+++ b/src/descriptor/pegin/legacy_pegin.rs
@@ -291,6 +291,8 @@ impl<Pk: MiniscriptKey> BtcLiftable<LegacyPeginKey> for LegacyPegin<Pk> {
 
 impl<Pk: MiniscriptKey> FromTree for LegacyPegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -316,6 +318,8 @@ where
 
 impl<Pk: MiniscriptKey> FromStr for LegacyPegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -330,6 +334,8 @@ where
 
 impl<Pk: MiniscriptKey> PeginTrait<Pk> for LegacyPegin<Pk>
 where
+    Pk: FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -24,7 +24,7 @@ use expression;
 use miniscript::{self, context::ScriptContext, decode::Terminal};
 use policy;
 use script_num_size;
-use {errstr, Error, Miniscript, MiniscriptKey, Satisfier, ToPublicKey};
+use {errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey};
 
 /// Contents of a "sortedmulti" descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -66,6 +66,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// Parse an expression tree into a SortedMultiVec
     pub fn from_tree(tree: &expression::Tree) -> Result<Self, Error>
     where
+        Pk: FromStr,
         <Pk as FromStr>::Err: ToString,
     {
         if tree.args.is_empty() {
@@ -84,9 +85,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
 
         pks.map(|pks| SortedMultiVec::new(k as usize, pks))?
     }
-}
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// This will panic if translatefpk returns an uncompressed key when
     /// converting to a Segwit descriptor. To prevent this panic, ensure
     /// translatefpk returns an error in this case instead.
@@ -106,6 +105,17 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         })
     }
 }
+
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for SortedMultiVec<Pk, Ctx> {
+    fn for_each_key<'a, F: FnMut(ForEach<'a, Pk>) -> bool>(&'a self, mut pred: F) -> bool
+    where
+        Pk: 'a,
+        Pk::Hash: 'a,
+    {
+        self.pks.iter().all(|key| pred(ForEach::Key(key)))
+    }
+}
+
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// utility function to sanity a sorted multi vec
     pub fn sanity_check(&self) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,8 @@ pub(crate) use bitcoin_miniscript::Terminal as BtcTerminal;
 // re-export imports
 pub use bitcoin_miniscript::{DummyKey, DummyKeyHash};
 pub use bitcoin_miniscript::{
-    MiniscriptKey, ToPublicKey, TranslatePk, TranslatePk1, TranslatePk2, TranslatePk3,
+    ForEach, ForEachKey, MiniscriptKey, ToPublicKey, TranslatePk, TranslatePk1, TranslatePk2,
+    TranslatePk3,
 };
 // End imports
 
@@ -159,7 +160,7 @@ pub use descriptor::{Descriptor, DescriptorPublicKey, DescriptorTrait};
 pub use interpreter::Interpreter;
 pub use miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0};
 pub use miniscript::decode::Terminal;
-pub use miniscript::satisfy::{ElementsSig, Satisfier};
+pub use miniscript::satisfy::{ElementsSig, Preimage32, Satisfier};
 pub use miniscript::Miniscript;
 
 /// Tweak a MiniscriptKey to obtain the tweaked key
@@ -179,7 +180,6 @@ where
     contracthash::tweak_key(secp, pk, contract)
 }
 /// Miniscript
-
 #[derive(Debug)]
 pub enum Error {
     /// Opcode appeared which is not part of the script subset

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,8 @@ macro_rules! serde_string_impl_pk {
         #[cfg(feature = "serde")]
         impl<'de, Pk $(, $gen)*> $crate::serde::Deserialize<'de> for $name<Pk $(, $gen)*>
         where
-            Pk: $crate::MiniscriptKey,
+            Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
+            Pk::Hash: $crate::std::str::FromStr,
             <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
             <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
                 $crate::std::fmt::Display,
@@ -41,7 +42,8 @@ macro_rules! serde_string_impl_pk {
                 struct Visitor<Pk $(, $gen)*>(PhantomData<(Pk $(, $gen)*)>);
                 impl<'de, Pk $(, $gen)*> $crate::serde::de::Visitor<'de> for Visitor<Pk $(, $gen)*>
                 where
-                    Pk: $crate::MiniscriptKey,
+                    Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
+                    Pk::Hash: $crate::std::str::FromStr,
                     <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
                     <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
                         $crate::std::fmt::Display,

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -255,7 +255,7 @@ pub trait ScriptContext:
 /// To be used as P2SH scripts
 /// For creation of Bare scriptpubkeys, construct the Miniscript
 /// under `Bare` ScriptContext
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Legacy {}
 
 impl ScriptContext for Legacy {
@@ -326,7 +326,7 @@ impl ScriptContext for Legacy {
 }
 
 /// Segwitv0 ScriptContext
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Segwitv0 {}
 
 impl ScriptContext for Segwitv0 {
@@ -418,7 +418,7 @@ impl ScriptContext for Segwitv0 {
 /// To be used as raw script pubkeys
 /// In general, it is not recommended to use Bare descriptors
 /// as they as strongly limited by standardness policies.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum BareCtx {}
 
 impl ScriptContext for BareCtx {
@@ -480,7 +480,7 @@ impl ScriptContext for BareCtx {
 /// Used by the "satisified constraints" iterator, which is intended to read
 /// scripts off of the blockchain without doing any sanity checks on them.
 /// This context should not be used unless you know what you are doing.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum NoChecks {}
 impl ScriptContext for NoChecks {
     fn check_terminal_non_malleable<Pk: MiniscriptKey, Ctx: ScriptContext>(

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -52,7 +52,7 @@ use miniscript::types::Type;
 use std::cmp;
 use std::sync::Arc;
 use MiniscriptKey;
-use {expression, Error, ToPublicKey, TranslatePk};
+use {expression, Error, ForEach, ForEachKey, ToPublicKey, TranslatePk};
 
 /// Top-level script AST type
 #[derive(Clone, Hash)]
@@ -232,6 +232,16 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 }
 
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Miniscript<Pk, Ctx> {
+    fn for_each_key<'a, F: FnMut(ForEach<'a, Pk>) -> bool>(&'a self, mut pred: F) -> bool
+    where
+        Pk: 'a,
+        Pk::Hash: 'a,
+    {
+        self.real_for_each_key(&mut pred)
+    }
+}
+
 impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
     for Miniscript<Pk, Ctx>
 {
@@ -254,6 +264,14 @@ impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
 }
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
+    fn real_for_each_key<'a, F: FnMut(ForEach<'a, Pk>) -> bool>(&'a self, pred: &mut F) -> bool
+    where
+        Pk: 'a,
+        Pk::Hash: 'a,
+    {
+        self.node.real_for_each_key(pred)
+    }
+
     fn real_translate_pk<FPk, FPkh, Q, FuncError>(
         &self,
         translatefpk: &mut FPk,
@@ -285,6 +303,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// accept sane scripts.
     pub fn from_str_insane(s: &str) -> Result<Miniscript<Pk, Ctx>, Error>
     where
+        Pk: str::FromStr,
+        Pk::Hash: str::FromStr,
         <Pk as str::FromStr>::Err: ToString,
         <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
     {
@@ -346,7 +366,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 impl<Pk, Ctx> expression::FromTree for Arc<Miniscript<Pk, Ctx>>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -358,7 +379,8 @@ where
 
 impl<Pk, Ctx> expression::FromTree for Miniscript<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -381,7 +403,8 @@ where
 /// do not clear the [Miniscript::sanity_check] checks.
 impl<Pk, Ctx> str::FromStr for Miniscript<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -443,7 +466,8 @@ mod tests {
         expected_debug: Str1,
         expected_display: Str2,
     ) where
-        Pk: MiniscriptKey,
+        Pk: MiniscriptKey + str::FromStr,
+        Pk::Hash: str::FromStr,
         Ctx: ScriptContext,
         <Pk as str::FromStr>::Err: ToString,
         <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -43,6 +43,8 @@ use Terminal;
 
 /// Type alias for a signature/hashtype pair
 pub type ElementsSig = (secp256k1::Signature, elements::SigHashType);
+/// Type alias for 32 byte Preimage.
+pub type Preimage32 = [u8; 32];
 
 /// Helper function to create ElementsSig from Rawsig
 /// Useful for downstream when implementing Satisfier.
@@ -77,22 +79,22 @@ pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     }
 
     /// Given a SHA256 hash, look up its preimage
-    fn lookup_sha256(&self, _: sha256::Hash) -> Option<[u8; 32]> {
+    fn lookup_sha256(&self, _: sha256::Hash) -> Option<Preimage32> {
         None
     }
 
     /// Given a HASH256 hash, look up its preimage
-    fn lookup_hash256(&self, _: sha256d::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash256(&self, _: sha256d::Hash) -> Option<Preimage32> {
         None
     }
 
     /// Given a RIPEMD160 hash, look up its preimage
-    fn lookup_ripemd160(&self, _: ripemd160::Hash) -> Option<[u8; 32]> {
+    fn lookup_ripemd160(&self, _: ripemd160::Hash) -> Option<Preimage32> {
         None
     }
 
     /// Given a HASH160 hash, look up its preimage
-    fn lookup_hash160(&self, _: hash160::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash160(&self, _: hash160::Hash) -> Option<Preimage32> {
         None
     }
 
@@ -182,7 +184,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for Older {
 
         let mask = SEQUENCE_LOCKTIME_MASK | SEQUENCE_LOCKTIME_TYPE_FLAG;
         let masked_n = n & mask;
-        let masked_seq = n & self.0;
+        let masked_seq = self.0 & mask;
         if masked_n < SEQUENCE_LOCKTIME_TYPE_FLAG && masked_seq >= SEQUENCE_LOCKTIME_TYPE_FLAG {
             false
         } else {
@@ -243,19 +245,19 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
         (**self).lookup_pkh_sig(pkh)
     }
 
-    fn lookup_sha256(&self, h: sha256::Hash) -> Option<[u8; 32]> {
+    fn lookup_sha256(&self, h: sha256::Hash) -> Option<Preimage32> {
         (**self).lookup_sha256(h)
     }
 
-    fn lookup_hash256(&self, h: sha256d::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash256(&self, h: sha256d::Hash) -> Option<Preimage32> {
         (**self).lookup_hash256(h)
     }
 
-    fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<[u8; 32]> {
+    fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<Preimage32> {
         (**self).lookup_ripemd160(h)
     }
 
-    fn lookup_hash160(&self, h: hash160::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash160(&self, h: hash160::Hash) -> Option<Preimage32> {
         (**self).lookup_hash160(h)
     }
 
@@ -325,19 +327,19 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
         (**self).lookup_pkh_sig(pkh)
     }
 
-    fn lookup_sha256(&self, h: sha256::Hash) -> Option<[u8; 32]> {
+    fn lookup_sha256(&self, h: sha256::Hash) -> Option<Preimage32> {
         (**self).lookup_sha256(h)
     }
 
-    fn lookup_hash256(&self, h: sha256d::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash256(&self, h: sha256d::Hash) -> Option<Preimage32> {
         (**self).lookup_hash256(h)
     }
 
-    fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<[u8; 32]> {
+    fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<Preimage32> {
         (**self).lookup_ripemd160(h)
     }
 
-    fn lookup_hash160(&self, h: hash160::Hash) -> Option<[u8; 32]> {
+    fn lookup_hash160(&self, h: hash160::Hash) -> Option<Preimage32> {
         (**self).lookup_hash160(h)
     }
 
@@ -438,7 +440,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_sha256(&self, h: sha256::Hash) -> Option<[u8; 32]> {
+            fn lookup_sha256(&self, h: sha256::Hash) -> Option<Preimage32> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_sha256(h) {
@@ -448,7 +450,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_hash256(&self, h: sha256d::Hash) -> Option<[u8; 32]> {
+            fn lookup_hash256(&self, h: sha256d::Hash) -> Option<Preimage32> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_hash256(h) {
@@ -458,7 +460,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<[u8; 32]> {
+            fn lookup_ripemd160(&self, h: ripemd160::Hash) -> Option<Preimage32> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_ripemd160(h) {
@@ -468,7 +470,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_hash160(&self, h: hash160::Hash) -> Option<[u8; 32]> {
+            fn lookup_hash160(&self, h: hash160::Hash) -> Option<Preimage32> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_hash160(h) {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -23,7 +23,7 @@ use elements::hashes::{hash160, ripemd160, sha256, sha256d};
 use super::concrete::PolicyError;
 use errstr;
 use Error;
-use {expression, MiniscriptKey};
+use {expression, ForEach, ForEachKey, MiniscriptKey};
 
 use super::ENTAILMENT_MAX_TERMINALS;
 
@@ -55,6 +55,26 @@ pub enum Policy<Pk: MiniscriptKey> {
     Hash160(hash160::Hash),
     /// A set of descriptors, satisfactions must be provided for `k` of them
     Threshold(usize, Vec<Policy<Pk>>),
+}
+
+impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
+    fn for_each_key<'a, F: FnMut(ForEach<'a, Pk>) -> bool>(&'a self, mut pred: F) -> bool
+    where
+        Pk: 'a,
+        Pk::Hash: 'a,
+    {
+        match *self {
+            Policy::Unsatisfiable | Policy::Trivial => true,
+            Policy::KeyHash(ref pkh) => pred(ForEach::Hash(pkh)),
+            Policy::Sha256(..)
+            | Policy::Hash256(..)
+            | Policy::Ripemd160(..)
+            | Policy::Hash160(..)
+            | Policy::After(..)
+            | Policy::Older(..) => true,
+            Policy::Threshold(_, ref subs) => subs.iter().all(|sub| sub.for_each_key(&mut pred)),
+        }
+    }
 }
 
 impl<Pk: MiniscriptKey> Policy<Pk> {
@@ -238,7 +258,8 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
 
 impl<Pk> str::FromStr for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {
@@ -260,7 +281,8 @@ serde_string_impl_pk!(Policy, "a miniscript semantic policy");
 
 impl<Pk> expression::FromTree for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -317,7 +317,7 @@ pub fn finalize<C: secp256k1::Verification>(
         input.partial_sigs.clear();
         input.sighash_type = None;
         input.redeem_script = None;
-        input.hd_keypaths.clear();
+        input.bip32_derivation.clear();
         input.witness_script = None;
     }
     // Double check everything with the interpreter


### PR DESCRIPTION
This is a single commit that contains all the changes in the rebase. The rebase history can be found in branch `rebased_cov` . https://github.com/sanket1729/elements-miniscript/tree/rebased_cov . 

The diff between the rebase branch and the first commit HEAD is null. 

The second commit is a redoing of fuzz fix because I missed it in the rebase process. 